### PR TITLE
Dbus messaging overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Cargo.lock
 /target/
+debian
+*.deb

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systemd-manager"
-version = "0.4.2"
+version = "0.4.3"
 license = "GPL-3.0"
 repository = "https://github.com/mmstick/systemd-manager"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systemd-manager"
-version = "0.4.3"
+version = "0.5.0"
 license = "GPL-3.0"
 repository = "https://github.com/mmstick/systemd-manager"
 readme = "README.md"

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-if [ "$(cat /etc/os-release | grep ubuntu)" ]; then
+if grep -q "ubuntu" "/etc/os-release"; then
     sudo apt install libgtk-3-dev
-    cargo build --release
-    version=$(cat Cargo.toml | grep version | awk -F\" '{print $2}')
+    cargo build --release || exit 1
+    version=$(grep "version" "Cargo.toml" | awk -F\" '{print $2}')
     if [ "$(getconf LONG_BIT)" = "64" ]; then arch=amd64; else arch=i386; fi
     mkdir -p debian/usr/bin
     mkdir -p debian/usr/share/applications
@@ -11,10 +11,10 @@ if [ "$(cat /etc/os-release | grep ubuntu)" ]; then
     cp assets/systemd-manager-pkexec debian/usr/bin/
     cp assets/systemd-manager.desktop debian/usr/share/applications/
     cp assets/org.freedesktop.policykit.systemd-manager.policy debian/usr/share/polkit-1/actions
-    dpkg-deb --build debian systemd-manager_${version}_${arch}.deb
-    sudo dpkg -i systemd-manager_${version}_${arch}.deb
+    dpkg-deb --build debian "systemd-manager_${version}_${arch}.deb" || exit 1
+    sudo dpkg -i "systemd-manager_${version}_${arch}.deb" || exit 1
 else
-    cargo build --release
+    cargo build --release || exit 1
     sudo cp target/release/systemd-manager /usr/bin/
     sudo cp assets/systemd-manager-pkexec /usr/bin/
     sudo cp assets/systemd-manager.desktop /usr/share/applications/

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
 use std::env;
 
-use systemd::dbus::BUS_TYPE;
-
 extern crate gdk;
 extern crate gtk;
 mod systemd_gui; // Contains all of the heavy GUI-related work
@@ -11,15 +9,30 @@ mod systemd {
 }
 
 fn main() {
+    let mut config = Config::default();
     for arg in env::args().skip(1) {
         match arg.as_ref() {
             "--user" => {
-                *BUS_TYPE.lock().unwrap() = dbus::BusType::Session;
+                config.bus_type = dbus::BusType::Session;
             }
             x => {
                 panic!("Unrecognized CLI argument {:?}", x);
             }
         }
     }
-    systemd_gui::launch();
+    systemd_gui::launch(config);
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// The bus type to use. Defaults to System, can be instead Session to access the user dbus.
+    bus_type: dbus::BusType,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            bus_type: dbus::BusType::System,
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,12 @@ pub struct Config {
     bus_type: dbus::BusType,
 }
 
+impl Config {
+    pub fn user(&self) -> bool {
+        self.bus_type == dbus::BusType::Session
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,25 @@
-extern crate gtk;
+use std::env;
+
+use systemd::dbus::BUS_TYPE;
+
 extern crate gdk;
-mod systemd_gui;     // Contains all of the heavy GUI-related work
+extern crate gtk;
+mod systemd_gui; // Contains all of the heavy GUI-related work
 mod systemd {
     pub mod analyze; // Support for systemd-analyze
-    pub mod dbus;    // The dbus backend for systemd
+    pub mod dbus; // The dbus backend for systemd
 }
 
 fn main() {
+    for arg in env::args().skip(1) {
+        match arg.as_ref() {
+            "--user" => {
+                *BUS_TYPE.lock().unwrap() = dbus::BusType::Session;
+            }
+            x => {
+                panic!("Unrecognized CLI argument {:?}", x);
+            }
+        }
+    }
     systemd_gui::launch();
 }

--- a/src/systemd/analyze.rs
+++ b/src/systemd/analyze.rs
@@ -11,23 +11,33 @@ impl Analyze {
     pub fn blame() -> Vec<Analyze> {
         fn parse_time(input: &str) -> u32 {
             if input.ends_with("ms") {
-                input[0..input.len()-2].parse::<u32>().unwrap_or(0)
+                input[0..input.len() - 2].parse::<u32>().unwrap_or(0)
             } else if input.ends_with('s') {
-                (input[0..input.len()-1].parse::<f32>().unwrap_or(0f32) * 1000f32) as u32
+                (input[0..input.len() - 1].parse::<f32>().unwrap_or(0f32) * 1000f32) as u32
             } else if input.ends_with("min") {
-                input[0..input.len()-3].parse::<u32>().unwrap_or(0) * 3600000
+                input[0..input.len() - 3].parse::<u32>().unwrap_or(0) * 3600000
             } else {
                 0u32
             }
         }
 
-        String::from_utf8(Command::new("systemd-analyze").arg("blame").output().unwrap().stdout).unwrap()
-            .lines().rev().map(|x| {
-                let mut iterator = x.split_whitespace();
-                Analyze {
-                    time: parse_time(iterator.next().unwrap()),
-                    service: String::from(iterator.next().unwrap())
-                }
-            }).collect::<Vec<Analyze>>()
+        String::from_utf8(
+            Command::new("systemd-analyze")
+                .arg("blame")
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .lines()
+        .rev()
+        .map(|x| {
+            let mut iterator = x.split_whitespace();
+            Analyze {
+                time: parse_time(iterator.next().unwrap()),
+                service: String::from(iterator.next().unwrap()),
+            }
+        })
+        .collect::<Vec<Analyze>>()
     }
 }

--- a/src/systemd/analyze.rs
+++ b/src/systemd/analyze.rs
@@ -23,7 +23,7 @@ impl Analyze {
 
         String::from_utf8(Command::new("systemd-analyze").arg("blame").output().unwrap().stdout).unwrap()
             .lines().rev().map(|x| {
-                let mut iterator = x.trim().split_whitespace();
+                let mut iterator = x.split_whitespace();
                 Analyze {
                     time: parse_time(iterator.next().unwrap()),
                     service: String::from(iterator.next().unwrap())

--- a/src/systemd/dbus.rs
+++ b/src/systemd/dbus.rs
@@ -95,7 +95,7 @@ pub fn list_unit_files() -> Vec<SystemdUnit> {
             let name: String = name.chars().skip(14).take_while(|x| *x != '\"').collect();
             let utype = UnitType::new(&name);
             let state = UnitState::new(iterator.next().unwrap());
-            systemd_units.push(SystemdUnit{name: name, state: state, utype: utype});
+            systemd_units.push(SystemdUnit{name, state, utype});
         }
 
         systemd_units.sort_by(|a, b| a.name.cmp(&b.name));

--- a/src/systemd/dbus.rs
+++ b/src/systemd/dbus.rs
@@ -13,7 +13,7 @@ macro_rules! dbus_message {
 }
 
 /// The bus type to send messages on. Determines whether we're controlling the system or the user systemd units.
-/// TODO: sort of a hack; the better solution would be to pass the various settings around in a struct.
+/// TODO: sort of a hack; the better solution would be to pass the bus type along with other settings around in a struct.
 pub static BUS_TYPE: Mutex<dbus::BusType> = Mutex::new(dbus::BusType::System);
 
 /// Takes a `dbus::Message` as input and makes a connection to dbus, returning the reply.

--- a/src/systemd/dbus.rs
+++ b/src/systemd/dbus.rs
@@ -1,28 +1,17 @@
 extern crate dbus;
 use std::{path::Path, sync::Mutex};
 
+/// Whether to print debug messages in DbusHandle::send.
+const SEND_DEBUG: bool = false;
+
 /// Takes a systemd dbus function as input and returns the result as a `dbus::Message`.
 macro_rules! dbus_message {
     ($function:expr) => {{
         let dest = "org.freedesktop.systemd1";
         let node = "/org/freedesktop/systemd1";
         let interface = "org.freedesktop.systemd1.Manager";
-        dbus::Message::new_method_call(dest, node, interface, $function)
-            .unwrap_or_else(|e| panic!("{}", e))
+        dbus::Message::new_method_call(dest, node, interface, $function).unwrap()
     }};
-}
-
-/// The bus type to send messages on. Determines whether we're controlling the system or the user systemd units.
-/// TODO: sort of a hack; the better solution would be to pass the bus type along with other settings around in a struct.
-pub static BUS_TYPE: Mutex<dbus::BusType> = Mutex::new(dbus::BusType::System);
-
-/// Takes a `dbus::Message` as input and makes a connection to dbus, returning the reply.
-macro_rules! dbus_connect {
-    ($message:expr) => {
-        dbus::Connection::get_private(*BUS_TYPE.lock().unwrap())
-            .unwrap()
-            .send_with_reply_and_block($message, 4000)
-    };
 }
 
 #[derive(Clone)]
@@ -100,46 +89,165 @@ impl UnitState {
     }
 }
 
-/// Communicates with dbus to obtain a list of unit files and returns them as a `Vec<SystemdUnit>`.
-pub fn list_unit_files() -> Vec<SystemdUnit> {
-    /// Takes the dbus message as input and maps the information to a `Vec<SystemdUnit>`.
-    fn parse_message(input: &str) -> Vec<SystemdUnit> {
-        let message = {
-            let mut output: String = input.chars().skip(7).collect();
-            let len = output.len() - 10;
-            output.truncate(len);
-            output
-        };
-
-        // This custom loop iterates across two variables at a time. The first variable contains the
-        // pathname of the unit, while the second variable contains the state of that unit.
-        let mut systemd_units: Vec<SystemdUnit> = Vec::new();
-        let mut iterator = message.split(',');
-        while let Some(name) = iterator.next() {
-            let name: String = name.chars().skip(14).take_while(|x| *x != '\"').collect();
-            let utype = UnitType::new(&name);
-            let state = UnitState::new(iterator.next().unwrap());
-            systemd_units.push(SystemdUnit { name, state, utype });
+#[derive(Debug)]
+pub struct DbusHandle {
+    bus_type: dbus::BusType,
+    connection: Mutex<Option<dbus::Connection>>,
+}
+impl DbusHandle {
+    pub fn new(bus_type: dbus::BusType) -> Self {
+        Self {
+            bus_type,
+            connection: None.into(),
         }
-
-        systemd_units.sort_by(|a, b| a.name.cmp(&b.name));
-        systemd_units
     }
 
-    let message = dbus_connect!(dbus_message!("ListUnitFiles"))
-        .unwrap()
-        .get_items();
-    parse_message(&format!("{:?}", message))
+    /// Obtain a reference to the dbus::Connection, establishing it if necessary.
+    pub fn con(&self) -> std::sync::MutexGuard<'_, Option<dbus::Connection>> {
+        let mut conn = self.connection.lock().unwrap();
+        if conn.is_none() {
+            *conn = dbus::Connection::get_private(self.bus_type)
+                .expect("Failed to establish dbus connection")
+                .into();
+        }
+        // TODO: When MappedMutexGuard gets stabilized, can unwrap the option here.
+        conn
+    }
+    /// Sends a dbus message and waits for a reply.
+    pub fn send(&self, message: dbus::Message) -> Result<dbus::Message, dbus::Error> {
+        if SEND_DEBUG {
+            println!(
+                "Sending message {:?} from thread {:?}",
+                message,
+                std::thread::current().id()
+            );
+        }
+        self.con()
+            .as_ref()
+            .unwrap()
+            .send_with_reply_and_block(message, 4000)
+    }
+    /// Sends a function call message and waits for a reply.
+    pub fn call(&self, function_name: &str) -> Result<dbus::Message, dbus::Error> {
+        self.send(dbus_message!(function_name))
+    }
+    /// Communicates with dbus to obtain a list of unit files and returns them as a `Vec<SystemdUnit>`.
+    pub fn list_unit_files(&self) -> Vec<SystemdUnit> {
+        let message = self.call("ListUnitFiles").unwrap().get_items();
+        parse_units_from_message(&format!("{:?}", message))
+    }
+
+    /// Returns the current enablement status of the unit
+    pub fn get_unit_file_state(&self, path: &str) -> bool {
+        for unit in self.list_unit_files() {
+            if unit.name.as_str() == path {
+                return unit.state == UnitState::Enabled;
+            }
+        }
+        false
+    }
+
+    /// Takes the unit pathname of a service and enables it via dbus.
+    /// If dbus replies with `[Bool(true), Array([], "(sss)")]`, the service is already enabled.
+    pub fn enable_unit_files(&self, unit: &str) -> Option<String> {
+        let mut message = dbus_message!("EnableUnitFiles");
+        message.append_items(&[[unit][..].into(), false.into(), true.into()]);
+        match self.send(message) {
+            Ok(reply) => {
+                if format!("{:?}", reply.get_items()) == "[Bool(true), Array([], \"(sss)\")]" {
+                    println!("{} already enabled", unit);
+                } else {
+                    println!("{} has been enabled", unit);
+                }
+                None
+            }
+            Err(reply) => {
+                let error = format!("Error enabling {}:\n{:?}", unit, reply);
+                println!("{}", error);
+                Some(error)
+            }
+        }
+    }
+
+    /// Takes the unit pathname as input and disables it via dbus.
+    /// If dbus replies with `[Array([], "(sss)")]`, the service is already disabled.
+    pub fn disable_unit_files(&self, unit: &str) -> Option<String> {
+        let mut message = dbus_message!("DisableUnitFiles");
+        message.append_items(&[[unit][..].into(), false.into()]);
+        match self.send(message) {
+            Ok(reply) => {
+                if format!("{:?}", reply.get_items()) == "[Array([], \"(sss)\")]" {
+                    println!("{} is already disabled", unit);
+                } else {
+                    println!("{} has been disabled", unit);
+                }
+                None
+            }
+            Err(reply) => {
+                let error = format!("Error disabling {}:\n{:?}", unit, reply);
+                println!("{}", error);
+                Some(error)
+            }
+        }
+    }
+
+    /// Takes a unit name as input and attempts to start it
+    pub fn start_unit(&self, unit: &str) -> Option<String> {
+        let mut message = dbus_message!("StartUnit");
+        message.append_items(&[unit.into(), "fail".into()]);
+        match self.send(message) {
+            Ok(_) => {
+                println!("{} successfully started", unit);
+                None
+            }
+            Err(error) => {
+                let output = format!("{} failed to start:\n{:?}", unit, error);
+                println!("{}", output);
+                Some(output)
+            }
+        }
+    }
+
+    /// Takes a unit name as input and attempts to stop it.
+    pub fn stop_unit(&self, unit: &str) -> Option<String> {
+        let mut message = dbus_message!("StopUnit");
+        message.append_items(&[unit.into(), "fail".into()]);
+        match self.send(message) {
+            Ok(_) => {
+                println!("{} successfully stopped", unit);
+                None
+            }
+            Err(error) => {
+                let output = format!("{} failed to stop:\n{:?}", unit, error);
+                println!("{}", output);
+                Some(output)
+            }
+        }
+    }
 }
 
-/// Returns the current enablement status of the unit
-pub fn get_unit_file_state(path: &str) -> bool {
-    for unit in list_unit_files() {
-        if unit.name.as_str() == path {
-            return unit.state == UnitState::Enabled;
-        }
+/// Takes the dbus message as input and maps the information to a `Vec<SystemdUnit>`.
+fn parse_units_from_message(input: &str) -> Vec<SystemdUnit> {
+    let message = {
+        let mut output: String = input.chars().skip(7).collect();
+        let len = output.len() - 10;
+        output.truncate(len);
+        output
+    };
+
+    // This custom loop iterates across two variables at a time. The first variable contains the
+    // pathname of the unit, while the second variable contains the state of that unit.
+    let mut systemd_units: Vec<SystemdUnit> = Vec::new();
+    let mut iterator = message.split(',');
+    while let Some(name) = iterator.next() {
+        let name: String = name.chars().skip(14).take_while(|x| *x != '\"').collect();
+        let utype = UnitType::new(&name);
+        let state = UnitState::new(iterator.next().unwrap());
+        systemd_units.push(SystemdUnit { name, state, utype });
     }
-    false
+
+    systemd_units.sort_by(|a, b| a.name.cmp(&b.name));
+    systemd_units
 }
 
 /// Takes a `Vec<SystemdUnit>` as input and returns a new vector only containing services which can be enabled and
@@ -180,82 +288,4 @@ pub fn collect_togglable_timers(units: &[SystemdUnit]) -> Vec<SystemdUnit> {
         })
         .cloned()
         .collect()
-}
-
-/// Takes the unit pathname of a service and enables it via dbus.
-/// If dbus replies with `[Bool(true), Array([], "(sss)")]`, the service is already enabled.
-pub fn enable_unit_files(unit: &str) -> Option<String> {
-    let mut message = dbus_message!("EnableUnitFiles");
-    message.append_items(&[[unit][..].into(), false.into(), true.into()]);
-    match dbus_connect!(message) {
-        Ok(reply) => {
-            if format!("{:?}", reply.get_items()) == "[Bool(true), Array([], \"(sss)\")]" {
-                println!("{} already enabled", unit);
-            } else {
-                println!("{} has been enabled", unit);
-            }
-            None
-        }
-        Err(reply) => {
-            let error = format!("Error enabling {}:\n{:?}", unit, reply);
-            println!("{}", error);
-            Some(error)
-        }
-    }
-}
-
-/// Takes the unit pathname as input and disables it via dbus.
-/// If dbus replies with `[Array([], "(sss)")]`, the service is already disabled.
-pub fn disable_unit_files(unit: &str) -> Option<String> {
-    let mut message = dbus_message!("DisableUnitFiles");
-    message.append_items(&[[unit][..].into(), false.into()]);
-    match dbus_connect!(message) {
-        Ok(reply) => {
-            if format!("{:?}", reply.get_items()) == "[Array([], \"(sss)\")]" {
-                println!("{} is already disabled", unit);
-            } else {
-                println!("{} has been disabled", unit);
-            }
-            None
-        }
-        Err(reply) => {
-            let error = format!("Error disabling {}:\n{:?}", unit, reply);
-            println!("{}", error);
-            Some(error)
-        }
-    }
-}
-
-/// Takes a unit name as input and attempts to start it
-pub fn start_unit(unit: &str) -> Option<String> {
-    let mut message = dbus_message!("StartUnit");
-    message.append_items(&[unit.into(), "fail".into()]);
-    match dbus_connect!(message) {
-        Ok(_) => {
-            println!("{} successfully started", unit);
-            None
-        }
-        Err(error) => {
-            let output = format!("{} failed to start:\n{:?}", unit, error);
-            println!("{}", output);
-            Some(output)
-        }
-    }
-}
-
-/// Takes a unit name as input and attempts to stop it.
-pub fn stop_unit(unit: &str) -> Option<String> {
-    let mut message = dbus_message!("StopUnit");
-    message.append_items(&[unit.into(), "fail".into()]);
-    match dbus_connect!(message) {
-        Ok(_) => {
-            println!("{} successfully stopped", unit);
-            None
-        }
-        Err(error) => {
-            let output = format!("{} failed to stop:\n{:?}", unit, error);
-            println!("{}", output);
-            Some(output)
-        }
-    }
 }

--- a/src/systemd_gui.rs
+++ b/src/systemd_gui.rs
@@ -107,9 +107,13 @@ fn get_unit_journal(unit_path: &str) -> String {
         .fold(String::with_capacity(log.len()), |acc, x| acc + "\n" + x)
 }
 
-// TODO: Fix clippy error and start using this everywhere
 fn get_filename(path: &str) -> &str {
-    Path::new(path).file_name().unwrap().to_str().unwrap()
+    let filename = Path::new(path)
+        .file_name()
+        .unwrap_or_else(|| panic!("Couldn't get filename of path {:?}", path));
+    filename
+        .to_str()
+        .unwrap_or_else(|| panic!("Filename {:?} wasn't valid unicode", filename))
 }
 
 pub fn launch() {
@@ -299,11 +303,7 @@ pub fn launch() {
                 "Services" => {
                     let index = services_list.get_selected_row().unwrap().get_index();
                     let service = &services[index as usize];
-                    let service_path = Path::new(service.name.as_str())
-                        .file_name()
-                        .unwrap()
-                        .to_str()
-                        .unwrap();
+                    let service_path = get_filename(&service.name);
                     if enabled && !dbus::get_unit_file_state(service.name.as_str()) {
                         dbus::enable_unit_files(service_path);
                         switch.set_state(true);
@@ -327,11 +327,8 @@ pub fn launch() {
                 "Timers" => {
                     let index = timers_list.get_selected_row().unwrap().get_index();
                     let timer = &timers[index as usize];
-                    let timer_path = Path::new(timer.name.as_str())
-                        .file_name()
-                        .unwrap()
-                        .to_str()
-                        .unwrap();
+                    let timer_path = get_filename(&timer.name);
+
                     if enabled && !dbus::get_unit_file_state(timer.name.as_str()) {
                         dbus::enable_unit_files(timer_path);
                         switch.set_state(true);
@@ -363,45 +360,21 @@ pub fn launch() {
                 "Services" => {
                     let index = services_list.get_selected_row().unwrap().get_index();
                     let service = &services[index as usize];
-                    if dbus::start_unit(
-                        Path::new(service.name.as_str())
-                            .file_name()
-                            .unwrap()
-                            .to_str()
-                            .unwrap(),
-                    )
-                    .is_none()
-                    {
+                    if dbus::start_unit(get_filename(&service.name)).is_none() {
                         update_icon(&services_icons[index as usize], true);
                     }
                 }
                 "Sockets" => {
                     let index = sockets_list.get_selected_row().unwrap().get_index();
                     let socket = &sockets[index as usize];
-                    if dbus::start_unit(
-                        Path::new(socket.name.as_str())
-                            .file_name()
-                            .unwrap()
-                            .to_str()
-                            .unwrap(),
-                    )
-                    .is_none()
-                    {
+                    if dbus::start_unit(get_filename(&socket.name)).is_none() {
                         update_icon(&sockets_icons[index as usize], true);
                     }
                 }
                 "Timers" => {
                     let index = timers_list.get_selected_row().unwrap().get_index();
                     let timer = &timers[index as usize];
-                    if dbus::start_unit(
-                        Path::new(timer.name.as_str())
-                            .file_name()
-                            .unwrap()
-                            .to_str()
-                            .unwrap(),
-                    )
-                    .is_none()
-                    {
+                    if dbus::start_unit(get_filename(timer.name.as_str())).is_none() {
                         update_icon(&timers_icons[index as usize], true);
                     }
                 }
@@ -427,45 +400,21 @@ pub fn launch() {
                 "Services" => {
                     let index = services_list.get_selected_row().unwrap().get_index();
                     let service = &services[index as usize];
-                    if dbus::stop_unit(
-                        Path::new(service.name.as_str())
-                            .file_name()
-                            .unwrap()
-                            .to_str()
-                            .unwrap(),
-                    )
-                    .is_none()
-                    {
+                    if dbus::stop_unit(get_filename(&service.name)).is_none() {
                         update_icon(&services_icons[index as usize], false);
                     }
                 }
                 "Sockets" => {
                     let index = sockets_list.get_selected_row().unwrap().get_index();
                     let socket = &sockets[index as usize];
-                    if dbus::stop_unit(
-                        Path::new(socket.name.as_str())
-                            .file_name()
-                            .unwrap()
-                            .to_str()
-                            .unwrap(),
-                    )
-                    .is_none()
-                    {
+                    if dbus::stop_unit(get_filename(&socket.name)).is_none() {
                         update_icon(&sockets_icons[index as usize], false);
                     }
                 }
                 "Timers" => {
                     let index = timers_list.get_selected_row().unwrap().get_index();
                     let timer = &timers[index as usize];
-                    if dbus::stop_unit(
-                        Path::new(timer.name.as_str())
-                            .file_name()
-                            .unwrap()
-                            .to_str()
-                            .unwrap(),
-                    )
-                    .is_none()
-                    {
+                    if dbus::stop_unit(get_filename(&timer.name)).is_none() {
                         update_icon(&timers_icons[index as usize], false);
                     }
                 }

--- a/src/systemd_gui.rs
+++ b/src/systemd_gui.rs
@@ -1,8 +1,8 @@
-use systemd::dbus::{self, UnitState};
-use systemd::analyze::Analyze;
+use gdk::keys::constants;
 use gtk;
 use gtk::prelude::*;
-use gdk::keys::constants;
+use systemd::analyze::Analyze;
+use systemd::dbus::{self, UnitState};
 
 use std::fs;
 use std::io::{Read, Write};
@@ -11,12 +11,21 @@ use std::process::Command;
 
 /// Updates the status icon for the selected unit
 fn update_icon(icon: &gtk::Image, state: bool) {
-    if state { icon.set_from_icon_name(Some("gtk-yes"), gtk::IconSize::Button); } else { icon.set_from_icon_name(Some("gtk-no"), gtk::IconSize::Button); }
+    if state {
+        icon.set_from_icon_name(Some("gtk-yes"), gtk::IconSize::Button);
+    } else {
+        icon.set_from_icon_name(Some("gtk-no"), gtk::IconSize::Button);
+    }
 }
 
 /// Create a `gtk::ListboxRow` and add it to the `gtk::ListBox`, and then add the `gtk::Image` to a vector so that we can later modify
 /// it when the state changes.
-fn create_row(row: &mut gtk::ListBoxRow, path: &Path, state: UnitState, state_icons: &mut Vec<gtk::Image>) {
+fn create_row(
+    row: &mut gtk::ListBoxRow,
+    path: &Path,
+    state: UnitState,
+    state_icons: &mut Vec<gtk::Image>,
+) {
     let filename = path.file_stem().unwrap().to_str().unwrap();
     let unit_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
     let unit_label = gtk::Label::new(Some(filename));
@@ -47,14 +56,14 @@ fn setup_systemd_analyze(builder: &gtk::Builder) {
     // A simple macro for adding a column to the preview tree.
     macro_rules! add_column {
         ($preview_tree:ident, $title:expr, $id:expr) => {{
-            let column   = gtk::TreeViewColumn::new();
+            let column = gtk::TreeViewColumn::new();
             let renderer = gtk::CellRendererText::new();
             column.set_title($title);
             column.set_resizable(true);
             column.pack_start(&renderer, true);
             column.add_attribute(&renderer, "text", $id);
             analyze_tree.append_column(&column);
-        }}
+        }};
     }
 
     add_column!(analyze_store, "Time (ms)", 0);
@@ -74,15 +83,28 @@ fn setup_systemd_analyze(builder: &gtk::Builder) {
 
 /// Updates the associated journal `TextView` with the contents of the unit's journal log.
 fn update_journal(journal: &gtk::TextView, unit_path: &str) {
-    journal.get_buffer().unwrap().set_text(get_unit_journal(unit_path).as_str());
+    journal
+        .get_buffer()
+        .unwrap()
+        .set_text(get_unit_journal(unit_path).as_str());
 }
 
 /// Obtains the journal log for the given unit.
 fn get_unit_journal(unit_path: &str) -> String {
-    let log = String::from_utf8(Command::new("journalctl").arg("-b").arg("-u")
-        .arg(Path::new(unit_path).file_stem().unwrap().to_str().unwrap())
-        .output().unwrap().stdout).unwrap();
-    log.lines().rev().map(|x| x.trim()).fold(String::with_capacity(log.len()), |acc, x| acc + "\n" + x)
+    let log = String::from_utf8(
+        Command::new("journalctl")
+            .arg("-b")
+            .arg("-u")
+            .arg(Path::new(unit_path).file_stem().unwrap().to_str().unwrap())
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap();
+    log.lines()
+        .rev()
+        .map(|x| x.trim())
+        .fold(String::with_capacity(log.len()), |acc, x| acc + "\n" + x)
 }
 
 // TODO: Fix clippy error and start using this everywhere
@@ -94,28 +116,29 @@ pub fn launch() {
     gtk::init().unwrap_or_else(|_| panic!("tv-renamer: failed to initialize GTK."));
 
     let builder = gtk::Builder::from_string(include_str!("interface.glade"));
-    let window: gtk::Window               = builder.get_object("main_window").unwrap();
-    let unit_stack: gtk::Stack            = builder.get_object("unit_stack").unwrap();
-    let services_list: gtk::ListBox       = builder.get_object("services_list").unwrap();
-    let sockets_list: gtk::ListBox        = builder.get_object("sockets_list").unwrap();
-    let timers_list: gtk::ListBox         = builder.get_object("timers_list").unwrap();
-    let unit_info: gtk::TextView          = builder.get_object("unit_info").unwrap();
-    let ablement_switch: gtk::Switch      = builder.get_object("ablement_switch").unwrap();
-    let start_button: gtk::Button         = builder.get_object("start_button").unwrap();
-    let stop_button: gtk::Button          = builder.get_object("stop_button").unwrap();
-    let save_unit_file: gtk::Button       = builder.get_object("save_button").unwrap();
-    let unit_menu_label: gtk::Label       = builder.get_object("unit_menu_label").unwrap();
-    let unit_popover: gtk::PopoverMenu    = builder.get_object("unit_menu_popover").unwrap();
-    let services_button: gtk::Button      = builder.get_object("services_button").unwrap();
-    let sockets_button: gtk::Button       = builder.get_object("sockets_button").unwrap();
-    let timers_button: gtk::Button        = builder.get_object("timers_button").unwrap();
-    let unit_journal: gtk::TextView       = builder.get_object("unit_journal_view").unwrap();
-    let refresh_log_button: gtk::Button   = builder.get_object("refresh_log_button").unwrap();
-    let right_header: gtk::Label          = builder.get_object("header_service_label").unwrap();
+    let window: gtk::Window = builder.get_object("main_window").unwrap();
+    let unit_stack: gtk::Stack = builder.get_object("unit_stack").unwrap();
+    let services_list: gtk::ListBox = builder.get_object("services_list").unwrap();
+    let sockets_list: gtk::ListBox = builder.get_object("sockets_list").unwrap();
+    let timers_list: gtk::ListBox = builder.get_object("timers_list").unwrap();
+    let unit_info: gtk::TextView = builder.get_object("unit_info").unwrap();
+    let ablement_switch: gtk::Switch = builder.get_object("ablement_switch").unwrap();
+    let start_button: gtk::Button = builder.get_object("start_button").unwrap();
+    let stop_button: gtk::Button = builder.get_object("stop_button").unwrap();
+    let save_unit_file: gtk::Button = builder.get_object("save_button").unwrap();
+    let unit_menu_label: gtk::Label = builder.get_object("unit_menu_label").unwrap();
+    let unit_popover: gtk::PopoverMenu = builder.get_object("unit_menu_popover").unwrap();
+    let services_button: gtk::Button = builder.get_object("services_button").unwrap();
+    let sockets_button: gtk::Button = builder.get_object("sockets_button").unwrap();
+    let timers_button: gtk::Button = builder.get_object("timers_button").unwrap();
+    let unit_journal: gtk::TextView = builder.get_object("unit_journal_view").unwrap();
+    let refresh_log_button: gtk::Button = builder.get_object("refresh_log_button").unwrap();
+    let right_header: gtk::Label = builder.get_object("header_service_label").unwrap();
 
-    { // NOTE: Services Menu Button
-        let label   = unit_menu_label.clone();
-        let stack   = unit_stack.clone();
+    {
+        // NOTE: Services Menu Button
+        let label = unit_menu_label.clone();
+        let stack = unit_stack.clone();
         let popover = unit_popover.clone();
         services_button.connect_clicked(move |_| {
             stack.set_visible_child_name("Services");
@@ -124,7 +147,8 @@ pub fn launch() {
         });
     }
 
-    { // NOTE: Sockets Menu Button
+    {
+        // NOTE: Sockets Menu Button
         let label = unit_menu_label.clone();
         let stack = unit_stack.clone();
         let popover = unit_popover.clone();
@@ -135,7 +159,8 @@ pub fn launch() {
         });
     }
 
-    { // NOTE: Timers Menu Button
+    {
+        // NOTE: Timers Menu Button
         let label = unit_menu_label.clone();
         let stack = unit_stack.clone();
         let popover = unit_popover.clone();
@@ -157,22 +182,30 @@ pub fn launch() {
     let mut services_icons = Vec::new();
     for service in services.clone() {
         let mut unit_row = gtk::ListBoxRow::new();
-        create_row(&mut unit_row, Path::new(service.name.as_str()), service.state, &mut services_icons);
+        create_row(
+            &mut unit_row,
+            Path::new(service.name.as_str()),
+            service.state,
+            &mut services_icons,
+        );
         services_list.insert(&unit_row, -1);
     }
 
     {
-        let services        = services.clone();
-        let services_list   = services_list.clone();
-        let unit_info       = unit_info.clone();
+        let services = services.clone();
+        let services_list = services_list.clone();
+        let unit_info = unit_info.clone();
         let ablement_switch = ablement_switch.clone();
-        let unit_journal    = unit_journal.clone();
-        let header          = right_header.clone();
+        let unit_journal = unit_journal.clone();
+        let header = right_header.clone();
         services_list.connect_row_selected(move |_, row| {
             let index = row.unwrap().get_index();
             let service = &services[index as usize];
             let description = get_unit_info(service.name.as_str());
-            unit_info.get_buffer().unwrap().set_text(description.as_str());
+            unit_info
+                .get_buffer()
+                .unwrap()
+                .set_text(description.as_str());
             ablement_switch.set_active(dbus::get_unit_file_state(service.name.as_str()));
             ablement_switch.set_state(ablement_switch.get_active());
             update_journal(&unit_journal, service.name.as_str());
@@ -185,22 +218,30 @@ pub fn launch() {
     let mut sockets_icons = Vec::new();
     for socket in sockets.clone() {
         let mut unit_row = gtk::ListBoxRow::new();
-        create_row(&mut unit_row, Path::new(socket.name.as_str()), socket.state, &mut sockets_icons);
+        create_row(
+            &mut unit_row,
+            Path::new(socket.name.as_str()),
+            socket.state,
+            &mut sockets_icons,
+        );
         sockets_list.insert(&unit_row, -1);
     }
 
     {
-        let sockets         = sockets.clone();
-        let sockets_list    = sockets_list.clone();
-        let unit_info       = unit_info.clone();
+        let sockets = sockets.clone();
+        let sockets_list = sockets_list.clone();
+        let unit_info = unit_info.clone();
         let ablement_switch = ablement_switch.clone();
         let unit_journal = unit_journal.clone();
-        let header          = right_header.clone();
+        let header = right_header.clone();
         sockets_list.connect_row_selected(move |_, row| {
             let index = row.unwrap().get_index();
             let socket = &sockets[index as usize];
             let description = get_unit_info(socket.name.as_str());
-            unit_info.get_buffer().unwrap().set_text(description.as_str());
+            unit_info
+                .get_buffer()
+                .unwrap()
+                .set_text(description.as_str());
             ablement_switch.set_active(dbus::get_unit_file_state(socket.name.as_str()));
             ablement_switch.set_state(true);
             update_journal(&unit_journal, socket.name.as_str());
@@ -213,22 +254,30 @@ pub fn launch() {
     let mut timers_icons = Vec::new();
     for timer in timers.clone() {
         let mut unit_row = gtk::ListBoxRow::new();
-        create_row(&mut unit_row, Path::new(timer.name.as_str()), timer.state, &mut timers_icons);
+        create_row(
+            &mut unit_row,
+            Path::new(timer.name.as_str()),
+            timer.state,
+            &mut timers_icons,
+        );
         timers_list.insert(&unit_row, -1);
     }
 
     {
-        let timers          = timers.clone();
-        let timers_list     = timers_list.clone();
-        let unit_info       = unit_info.clone();
+        let timers = timers.clone();
+        let timers_list = timers_list.clone();
+        let unit_info = unit_info.clone();
         let ablement_switch = ablement_switch.clone();
         let unit_journal = unit_journal.clone();
-        let header          = right_header.clone();
+        let header = right_header.clone();
         timers_list.connect_row_selected(move |_, row| {
             let index = row.unwrap().get_index();
             let timer = &timers[index as usize];
             let description = get_unit_info(timer.name.as_str());
-            unit_info.get_buffer().unwrap().set_text(description.as_str());
+            unit_info
+                .get_buffer()
+                .unwrap()
+                .set_text(description.as_str());
             ablement_switch.set_active(dbus::get_unit_file_state(timer.name.as_str()));
             ablement_switch.set_state(true);
             update_journal(&unit_journal, timer.name.as_str());
@@ -236,195 +285,262 @@ pub fn launch() {
         });
     }
 
-    { // NOTE: Implement the {dis, en}able button
-    let services        = services.clone();
-    let services_list   = services_list.clone();
-    let sockets         = sockets.clone();
-    let sockets_list    = sockets_list.clone();
-    let timers          = timers.clone();
-    let timers_list     = timers_list.clone();
-    let unit_stack      = unit_stack.clone();
-    ablement_switch.connect_state_set(move |switch, enabled| {
-        match unit_stack.get_visible_child_name().unwrap().as_str() {
-            "Services" => {
-                let index   = services_list.get_selected_row().unwrap().get_index();
-                let service = &services[index as usize];
-                let service_path = Path::new(service.name.as_str()).file_name().unwrap().to_str().unwrap();
-                if enabled && !dbus::get_unit_file_state(service.name.as_str()) {
-                    dbus::enable_unit_files(service_path);
-                    switch.set_state(true);
-                } else if !enabled && dbus::get_unit_file_state(service.name.as_str()) {
-                    dbus::disable_unit_files(service_path);
-                    switch.set_state(false);
+    {
+        // NOTE: Implement the {dis, en}able button
+        let services = services.clone();
+        let services_list = services_list.clone();
+        let sockets = sockets.clone();
+        let sockets_list = sockets_list.clone();
+        let timers = timers.clone();
+        let timers_list = timers_list.clone();
+        let unit_stack = unit_stack.clone();
+        ablement_switch.connect_state_set(move |switch, enabled| {
+            match unit_stack.get_visible_child_name().unwrap().as_str() {
+                "Services" => {
+                    let index = services_list.get_selected_row().unwrap().get_index();
+                    let service = &services[index as usize];
+                    let service_path = Path::new(service.name.as_str())
+                        .file_name()
+                        .unwrap()
+                        .to_str()
+                        .unwrap();
+                    if enabled && !dbus::get_unit_file_state(service.name.as_str()) {
+                        dbus::enable_unit_files(service_path);
+                        switch.set_state(true);
+                    } else if !enabled && dbus::get_unit_file_state(service.name.as_str()) {
+                        dbus::disable_unit_files(service_path);
+                        switch.set_state(false);
+                    }
                 }
-            },
-            "Sockets" => {
-                let index   = sockets_list.get_selected_row().unwrap().get_index();
-                let socket  = &sockets[index as usize];
-                let socket_path = get_filename(socket.name.as_str());
-                if enabled && !dbus::get_unit_file_state(socket.name.as_str()) {
-                    dbus::enable_unit_files(socket_path);
-                    switch.set_state(true);
-                } else if !enabled && dbus::get_unit_file_state(socket.name.as_str()) {
-                    dbus::disable_unit_files(socket_path);
-                    switch.set_state(false);
+                "Sockets" => {
+                    let index = sockets_list.get_selected_row().unwrap().get_index();
+                    let socket = &sockets[index as usize];
+                    let socket_path = get_filename(socket.name.as_str());
+                    if enabled && !dbus::get_unit_file_state(socket.name.as_str()) {
+                        dbus::enable_unit_files(socket_path);
+                        switch.set_state(true);
+                    } else if !enabled && dbus::get_unit_file_state(socket.name.as_str()) {
+                        dbus::disable_unit_files(socket_path);
+                        switch.set_state(false);
+                    }
                 }
-            },
-            "Timers" => {
-                let index   = timers_list.get_selected_row().unwrap().get_index();
-                let timer  = &timers[index as usize];
-                let timer_path = Path::new(timer.name.as_str()).file_name().unwrap().to_str().unwrap();
-                if enabled && !dbus::get_unit_file_state(timer.name.as_str()) {
-                    dbus::enable_unit_files(timer_path);
-                    switch.set_state(true);
-                } else if !enabled && dbus::get_unit_file_state(timer.name.as_str()) {
-                    dbus::disable_unit_files(timer_path);
-                    switch.set_state(false);
+                "Timers" => {
+                    let index = timers_list.get_selected_row().unwrap().get_index();
+                    let timer = &timers[index as usize];
+                    let timer_path = Path::new(timer.name.as_str())
+                        .file_name()
+                        .unwrap()
+                        .to_str()
+                        .unwrap();
+                    if enabled && !dbus::get_unit_file_state(timer.name.as_str()) {
+                        dbus::enable_unit_files(timer_path);
+                        switch.set_state(true);
+                    } else if !enabled && dbus::get_unit_file_state(timer.name.as_str()) {
+                        dbus::disable_unit_files(timer_path);
+                        switch.set_state(false);
+                    }
                 }
-            },
-            _ => unreachable!()
-        }
-        gtk::Inhibit(true)
-    });
+                _ => unreachable!(),
+            }
+            gtk::Inhibit(true)
+        });
     }
 
-    { // NOTE: Implement the start button
-        let services       = services.clone();
-        let services_list  = services_list.clone();
-        let sockets        = sockets.clone();
-        let sockets_list   = sockets_list.clone();
-        let timers         = timers.clone();
-        let timers_list    = timers_list.clone();
+    {
+        // NOTE: Implement the start button
+        let services = services.clone();
+        let services_list = services_list.clone();
+        let sockets = sockets.clone();
+        let sockets_list = sockets_list.clone();
+        let timers = timers.clone();
+        let timers_list = timers_list.clone();
         let services_icons = services_icons.clone();
-        let sockets_icons  = sockets_icons.clone();
-        let timers_icons   = timers_icons.clone();
-        let unit_stack    = unit_stack.clone();
+        let sockets_icons = sockets_icons.clone();
+        let timers_icons = timers_icons.clone();
+        let unit_stack = unit_stack.clone();
         start_button.connect_clicked(move |_| {
             match unit_stack.get_visible_child_name().unwrap().as_str() {
                 "Services" => {
-                    let index   = services_list.get_selected_row().unwrap().get_index();
+                    let index = services_list.get_selected_row().unwrap().get_index();
                     let service = &services[index as usize];
-                    if dbus::start_unit(Path::new(service.name.as_str()).file_name().unwrap().to_str().unwrap()).is_none() {
+                    if dbus::start_unit(
+                        Path::new(service.name.as_str())
+                            .file_name()
+                            .unwrap()
+                            .to_str()
+                            .unwrap(),
+                    )
+                    .is_none()
+                    {
                         update_icon(&services_icons[index as usize], true);
                     }
-                },
+                }
                 "Sockets" => {
-                    let index   = sockets_list.get_selected_row().unwrap().get_index();
-                    let socket  = &sockets[index as usize];
-                    if dbus::start_unit(Path::new(socket.name.as_str()).file_name().unwrap().to_str().unwrap()).is_none() {
+                    let index = sockets_list.get_selected_row().unwrap().get_index();
+                    let socket = &sockets[index as usize];
+                    if dbus::start_unit(
+                        Path::new(socket.name.as_str())
+                            .file_name()
+                            .unwrap()
+                            .to_str()
+                            .unwrap(),
+                    )
+                    .is_none()
+                    {
                         update_icon(&sockets_icons[index as usize], true);
                     }
-                },
+                }
                 "Timers" => {
-                    let index   = timers_list.get_selected_row().unwrap().get_index();
-                    let timer  = &timers[index as usize];
-                    if dbus::start_unit(Path::new(timer.name.as_str()).file_name().unwrap().to_str().unwrap()).is_none() {
+                    let index = timers_list.get_selected_row().unwrap().get_index();
+                    let timer = &timers[index as usize];
+                    if dbus::start_unit(
+                        Path::new(timer.name.as_str())
+                            .file_name()
+                            .unwrap()
+                            .to_str()
+                            .unwrap(),
+                    )
+                    .is_none()
+                    {
                         update_icon(&timers_icons[index as usize], true);
                     }
-                },
-                _ => ()
+                }
+                _ => (),
             }
         });
     }
 
-    { // NOTE: Implement the stop button
-        let services       = services.clone();
-        let services_list  = services_list.clone();
-        let sockets        = sockets.clone();
-        let sockets_list   = sockets_list.clone();
-        let timers         = timers.clone();
-        let timers_list    = timers_list.clone();
+    {
+        // NOTE: Implement the stop button
+        let services = services.clone();
+        let services_list = services_list.clone();
+        let sockets = sockets.clone();
+        let sockets_list = sockets_list.clone();
+        let timers = timers.clone();
+        let timers_list = timers_list.clone();
         let services_icons = services_icons.clone();
-        let sockets_icons  = sockets_icons.clone();
-        let timers_icons   = timers_icons.clone();
-        let unit_stack    = unit_stack.clone();
+        let sockets_icons = sockets_icons.clone();
+        let timers_icons = timers_icons.clone();
+        let unit_stack = unit_stack.clone();
         stop_button.connect_clicked(move |_| {
             match unit_stack.get_visible_child_name().unwrap().as_str() {
                 "Services" => {
-                    let index   = services_list.get_selected_row().unwrap().get_index();
+                    let index = services_list.get_selected_row().unwrap().get_index();
                     let service = &services[index as usize];
-                    if dbus::stop_unit(Path::new(service.name.as_str()).file_name().unwrap().to_str().unwrap()).is_none() {
+                    if dbus::stop_unit(
+                        Path::new(service.name.as_str())
+                            .file_name()
+                            .unwrap()
+                            .to_str()
+                            .unwrap(),
+                    )
+                    .is_none()
+                    {
                         update_icon(&services_icons[index as usize], false);
                     }
-                },
+                }
                 "Sockets" => {
-                    let index   = sockets_list.get_selected_row().unwrap().get_index();
-                    let socket  = &sockets[index as usize];
-                    if dbus::stop_unit(Path::new(socket.name.as_str()).file_name().unwrap().to_str().unwrap()).is_none() {
+                    let index = sockets_list.get_selected_row().unwrap().get_index();
+                    let socket = &sockets[index as usize];
+                    if dbus::stop_unit(
+                        Path::new(socket.name.as_str())
+                            .file_name()
+                            .unwrap()
+                            .to_str()
+                            .unwrap(),
+                    )
+                    .is_none()
+                    {
                         update_icon(&sockets_icons[index as usize], false);
                     }
-                },
+                }
                 "Timers" => {
-                    let index   = timers_list.get_selected_row().unwrap().get_index();
-                    let timer   = &timers[index as usize];
-                    if dbus::stop_unit(Path::new(timer.name.as_str()).file_name().unwrap().to_str().unwrap()).is_none() {
+                    let index = timers_list.get_selected_row().unwrap().get_index();
+                    let timer = &timers[index as usize];
+                    if dbus::stop_unit(
+                        Path::new(timer.name.as_str())
+                            .file_name()
+                            .unwrap()
+                            .to_str()
+                            .unwrap(),
+                    )
+                    .is_none()
+                    {
                         update_icon(&timers_icons[index as usize], false);
                     }
-                },
-                _ => ()
+                }
+                _ => (),
             }
         });
     }
 
-    { // NOTE: Save Button
+    {
+        // NOTE: Save Button
         let unit_info = unit_info.clone();
-        let services      = services.clone();
+        let services = services.clone();
         let services_list = services_list.clone();
-        let sockets       = sockets.clone();
-        let sockets_list  = sockets_list.clone();
-        let timers        = timers.clone();
-        let timers_list   = timers_list.clone();
-        let unit_stack    = unit_stack.clone();
+        let sockets = sockets.clone();
+        let sockets_list = sockets_list.clone();
+        let timers = timers.clone();
+        let timers_list = timers_list.clone();
+        let unit_stack = unit_stack.clone();
         save_unit_file.connect_clicked(move |_| {
             let buffer = unit_info.get_buffer().unwrap();
-            let start  = buffer.get_start_iter();
-            let end    = buffer.get_end_iter();
-            let text   = buffer.get_text(&start, &end, true).unwrap();
+            let start = buffer.get_start_iter();
+            let end = buffer.get_end_iter();
+            let text = buffer.get_text(&start, &end, true).unwrap();
             let path = match unit_stack.get_visible_child_name().unwrap().as_str() {
-                "Services" => &services[services_list.get_selected_row().unwrap().get_index() as usize].name,
-                "Sockets" => &sockets[sockets_list.get_selected_row().unwrap().get_index() as usize].name,
-                "Timers" => &timers[timers_list.get_selected_row().unwrap().get_index() as usize].name,
-                _ => unreachable!()
+                "Services" => {
+                    &services[services_list.get_selected_row().unwrap().get_index() as usize].name
+                }
+                "Sockets" => {
+                    &sockets[sockets_list.get_selected_row().unwrap().get_index() as usize].name
+                }
+                "Timers" => {
+                    &timers[timers_list.get_selected_row().unwrap().get_index() as usize].name
+                }
+                _ => unreachable!(),
             };
             match fs::OpenOptions::new().write(true).open(path) {
                 Ok(mut file) => {
                     if let Err(message) = file.write(text.as_bytes()) {
                         println!("Unable to write to file: {:?}", message);
                     }
-                },
-                Err(message) => println!("Unable to open file: {:?}", message)
+                }
+                Err(message) => println!("Unable to open file: {:?}", message),
             }
         });
     }
 
-    { // NOTE: Journal Refresh Button
-        let services       = services.clone();
-        let services_list  = services_list.clone();
-        let sockets        = sockets.clone();
-        let sockets_list   = sockets_list.clone();
-        let timers         = timers.clone();
-        let timers_list    = timers_list.clone();
-        let unit_stack     = unit_stack.clone();
+    {
+        // NOTE: Journal Refresh Button
+        let services = services.clone();
+        let services_list = services_list.clone();
+        let sockets = sockets.clone();
+        let sockets_list = sockets_list.clone();
+        let timers = timers.clone();
+        let timers_list = timers_list.clone();
+        let unit_stack = unit_stack.clone();
         let refresh_button = refresh_log_button.clone();
-        let unit_journal   = unit_journal.clone();
+        let unit_journal = unit_journal.clone();
         refresh_button.connect_clicked(move |_| {
             match unit_stack.get_visible_child_name().unwrap().as_str() {
                 "Services" => {
-                    let index   = services_list.get_selected_row().unwrap().get_index();
+                    let index = services_list.get_selected_row().unwrap().get_index();
                     let service = &services[index as usize];
                     update_journal(&unit_journal, service.name.as_str());
-                },
+                }
                 "Sockets" => {
-                    let index   = sockets_list.get_selected_row().unwrap().get_index();
+                    let index = sockets_list.get_selected_row().unwrap().get_index();
                     let socket = &sockets[index as usize];
                     update_journal(&unit_journal, socket.name.as_str());
-                },
+                }
                 "Timers" => {
-                    let index   = timers_list.get_selected_row().unwrap().get_index();
+                    let index = timers_list.get_selected_row().unwrap().get_index();
                     let timer = &timers[index as usize];
                     update_journal(&unit_journal, timer.name.as_str());
-                },
-                _ => unreachable!()
+                }
+                _ => unreachable!(),
             }
         });
     }
@@ -439,7 +555,9 @@ pub fn launch() {
 
     // Define custom actions on keypress
     window.connect_key_press_event(move |_, key| {
-        if let constants::Escape = key.get_keyval() { gtk::main_quit() }
+        if let constants::Escape = key.get_keyval() {
+            gtk::main_quit()
+        }
         gtk::Inhibit(false)
     });
 

--- a/src/systemd_gui.rs
+++ b/src/systemd_gui.rs
@@ -291,8 +291,8 @@ pub fn launch(config: Config) {
                 .set_text(description.as_str());
             ablement_switch.set_active(handle.get_unit_file_state(get_filename(&timer.name)));
             ablement_switch.set_state(true);
-            update_journal(&unit_journal, timer.name.as_str(), usermode);
-            header.set_label(get_filename(timer.name.as_str()));
+            update_journal(&unit_journal, &timer.name, usermode);
+            header.set_label(get_filename(&timer.name));
         });
     }
 
@@ -311,37 +311,37 @@ pub fn launch(config: Config) {
                 "Services" => {
                     let index = services_list.get_selected_row().unwrap().get_index();
                     let service = &services[index as usize];
-                    let service_path = get_filename(&service.name);
-                    if enabled && !handle.get_unit_file_state(get_filename(&service.name)) {
-                        handle.enable_unit_files(service_path);
+                    let service_name = get_filename(&service.name);
+                    if enabled && !handle.get_unit_file_state(service_name) {
+                        handle.enable_unit_files(service_name);
                         switch.set_state(true);
-                    } else if !enabled && handle.get_unit_file_state(get_filename(&service.name)) {
-                        handle.disable_unit_files(service_path);
+                    } else if !enabled && handle.get_unit_file_state(service_name) {
+                        handle.disable_unit_files(service_name);
                         switch.set_state(false);
                     }
                 }
                 "Sockets" => {
                     let index = sockets_list.get_selected_row().unwrap().get_index();
                     let socket = &sockets[index as usize];
-                    let socket_path = get_filename(socket.name.as_str());
-                    if enabled && !handle.get_unit_file_state(get_filename(&socket.name)) {
-                        handle.enable_unit_files(socket_path);
+                    let socket_name = get_filename(&socket.name);
+                    if enabled && !handle.get_unit_file_state(socket_name) {
+                        handle.enable_unit_files(socket_name);
                         switch.set_state(true);
-                    } else if !enabled && handle.get_unit_file_state(get_filename(&socket.name)) {
-                        handle.disable_unit_files(socket_path);
+                    } else if !enabled && handle.get_unit_file_state(socket_name) {
+                        handle.disable_unit_files(socket_name);
                         switch.set_state(false);
                     }
                 }
                 "Timers" => {
                     let index = timers_list.get_selected_row().unwrap().get_index();
                     let timer = &timers[index as usize];
-                    let timer_path = get_filename(&timer.name);
+                    let timer_name = get_filename(&timer.name);
 
-                    if enabled && !handle.get_unit_file_state(get_filename(&timer.name)) {
-                        handle.enable_unit_files(timer_path);
+                    if enabled && !handle.get_unit_file_state(timer_name) {
+                        handle.enable_unit_files(timer_name);
                         switch.set_state(true);
-                    } else if !enabled && handle.get_unit_file_state(get_filename(&timer.name)) {
-                        handle.disable_unit_files(timer_path);
+                    } else if !enabled && handle.get_unit_file_state(timer_name) {
+                        handle.disable_unit_files(timer_name);
                         switch.set_state(false);
                     }
                 }
@@ -383,10 +383,7 @@ pub fn launch(config: Config) {
                 "Timers" => {
                     let index = timers_list.get_selected_row().unwrap().get_index();
                     let timer = &timers[index as usize];
-                    if handle
-                        .start_unit(get_filename(timer.name.as_str()))
-                        .is_none()
-                    {
+                    if handle.start_unit(get_filename(&timer.name)).is_none() {
                         update_icon(&timers_icons[index as usize], true);
                     }
                 }

--- a/src/systemd_gui.rs
+++ b/src/systemd_gui.rs
@@ -86,7 +86,7 @@ fn get_unit_journal(unit_path: &str) -> String {
 }
 
 // TODO: Fix clippy error and start using this everywhere
-fn get_filename<'a>(path: &'a str) -> &str {
+fn get_filename(path: &str) -> &str {
     Path::new(path).file_name().unwrap().to_str().unwrap()
 }
 
@@ -169,7 +169,7 @@ pub fn launch() {
         let unit_journal    = unit_journal.clone();
         let header          = right_header.clone();
         services_list.connect_row_selected(move |_, row| {
-            let index = row.clone().unwrap().get_index();
+            let index = row.unwrap().get_index();
             let service = &services[index as usize];
             let description = get_unit_info(service.name.as_str());
             unit_info.get_buffer().unwrap().set_text(description.as_str());
@@ -197,7 +197,7 @@ pub fn launch() {
         let unit_journal = unit_journal.clone();
         let header          = right_header.clone();
         sockets_list.connect_row_selected(move |_, row| {
-            let index = row.clone().unwrap().get_index();
+            let index = row.unwrap().get_index();
             let socket = &sockets[index as usize];
             let description = get_unit_info(socket.name.as_str());
             unit_info.get_buffer().unwrap().set_text(description.as_str());
@@ -225,7 +225,7 @@ pub fn launch() {
         let unit_journal = unit_journal.clone();
         let header          = right_header.clone();
         timers_list.connect_row_selected(move |_, row| {
-            let index = row.clone().unwrap().get_index();
+            let index = row.unwrap().get_index();
             let timer = &timers[index as usize];
             let description = get_unit_info(timer.name.as_str());
             unit_info.get_buffer().unwrap().set_text(description.as_str());
@@ -304,21 +304,21 @@ pub fn launch() {
                 "Services" => {
                     let index   = services_list.get_selected_row().unwrap().get_index();
                     let service = &services[index as usize];
-                    if let None = dbus::start_unit(Path::new(service.name.as_str()).file_name().unwrap().to_str().unwrap()) {
+                    if dbus::start_unit(Path::new(service.name.as_str()).file_name().unwrap().to_str().unwrap()).is_none() {
                         update_icon(&services_icons[index as usize], true);
                     }
                 },
                 "Sockets" => {
                     let index   = sockets_list.get_selected_row().unwrap().get_index();
                     let socket  = &sockets[index as usize];
-                    if let None = dbus::start_unit(Path::new(socket.name.as_str()).file_name().unwrap().to_str().unwrap()) {
+                    if dbus::start_unit(Path::new(socket.name.as_str()).file_name().unwrap().to_str().unwrap()).is_none() {
                         update_icon(&sockets_icons[index as usize], true);
                     }
                 },
                 "Timers" => {
                     let index   = timers_list.get_selected_row().unwrap().get_index();
                     let timer  = &timers[index as usize];
-                    if let None = dbus::start_unit(Path::new(timer.name.as_str()).file_name().unwrap().to_str().unwrap()) {
+                    if dbus::start_unit(Path::new(timer.name.as_str()).file_name().unwrap().to_str().unwrap()).is_none() {
                         update_icon(&timers_icons[index as usize], true);
                     }
                 },
@@ -343,21 +343,21 @@ pub fn launch() {
                 "Services" => {
                     let index   = services_list.get_selected_row().unwrap().get_index();
                     let service = &services[index as usize];
-                    if let None = dbus::stop_unit(Path::new(service.name.as_str()).file_name().unwrap().to_str().unwrap()) {
+                    if dbus::stop_unit(Path::new(service.name.as_str()).file_name().unwrap().to_str().unwrap()).is_none() {
                         update_icon(&services_icons[index as usize], false);
                     }
                 },
                 "Sockets" => {
                     let index   = sockets_list.get_selected_row().unwrap().get_index();
                     let socket  = &sockets[index as usize];
-                    if let None = dbus::stop_unit(Path::new(socket.name.as_str()).file_name().unwrap().to_str().unwrap()) {
+                    if dbus::stop_unit(Path::new(socket.name.as_str()).file_name().unwrap().to_str().unwrap()).is_none() {
                         update_icon(&sockets_icons[index as usize], false);
                     }
                 },
                 "Timers" => {
                     let index   = timers_list.get_selected_row().unwrap().get_index();
                     let timer   = &timers[index as usize];
-                    if let None = dbus::stop_unit(Path::new(timer.name.as_str()).file_name().unwrap().to_str().unwrap()) {
+                    if dbus::stop_unit(Path::new(timer.name.as_str()).file_name().unwrap().to_str().unwrap()).is_none() {
                         update_icon(&timers_icons[index as usize], false);
                     }
                 },
@@ -386,7 +386,7 @@ pub fn launch() {
                 "Timers" => &timers[timers_list.get_selected_row().unwrap().get_index() as usize].name,
                 _ => unreachable!()
             };
-            match fs::OpenOptions::new().write(true).open(&path) {
+            match fs::OpenOptions::new().write(true).open(path) {
                 Ok(mut file) => {
                     if let Err(message) = file.write(text.as_bytes()) {
                         println!("Unable to write to file: {:?}", message);

--- a/src/systemd_gui.rs
+++ b/src/systemd_gui.rs
@@ -213,7 +213,7 @@ pub fn launch(config: Config) {
                 .get_buffer()
                 .unwrap()
                 .set_text(description.as_str());
-            ablement_switch.set_active(handle.get_unit_file_state(&service.name));
+            ablement_switch.set_active(handle.get_unit_file_state(get_filename(&service.name)));
             ablement_switch.set_state(ablement_switch.get_active());
             update_journal(&unit_journal, &service.name);
             header.set_label(get_filename(&service.name));
@@ -250,7 +250,8 @@ pub fn launch(config: Config) {
                 .get_buffer()
                 .unwrap()
                 .set_text(description.as_str());
-            ablement_switch.set_active(handle.get_unit_file_state(socket.name.as_str()));
+            ablement_switch
+                .set_active(handle.get_unit_file_state(get_filename(socket.name.as_str())));
             ablement_switch.set_state(true);
             update_journal(&unit_journal, socket.name.as_str());
             header.set_label(get_filename(socket.name.as_str()));
@@ -287,7 +288,7 @@ pub fn launch(config: Config) {
                 .get_buffer()
                 .unwrap()
                 .set_text(description.as_str());
-            ablement_switch.set_active(handle.get_unit_file_state(timer.name.as_str()));
+            ablement_switch.set_active(handle.get_unit_file_state(get_filename(&timer.name)));
             ablement_switch.set_state(true);
             update_journal(&unit_journal, timer.name.as_str());
             header.set_label(get_filename(timer.name.as_str()));
@@ -310,10 +311,10 @@ pub fn launch(config: Config) {
                     let index = services_list.get_selected_row().unwrap().get_index();
                     let service = &services[index as usize];
                     let service_path = get_filename(&service.name);
-                    if enabled && !handle.get_unit_file_state(&service.name) {
+                    if enabled && !handle.get_unit_file_state(get_filename(&service.name)) {
                         handle.enable_unit_files(service_path);
                         switch.set_state(true);
-                    } else if !enabled && handle.get_unit_file_state(&service.name) {
+                    } else if !enabled && handle.get_unit_file_state(get_filename(&service.name)) {
                         handle.disable_unit_files(service_path);
                         switch.set_state(false);
                     }
@@ -322,10 +323,10 @@ pub fn launch(config: Config) {
                     let index = sockets_list.get_selected_row().unwrap().get_index();
                     let socket = &sockets[index as usize];
                     let socket_path = get_filename(socket.name.as_str());
-                    if enabled && !handle.get_unit_file_state(socket.name.as_str()) {
+                    if enabled && !handle.get_unit_file_state(get_filename(&socket.name)) {
                         handle.enable_unit_files(socket_path);
                         switch.set_state(true);
-                    } else if !enabled && handle.get_unit_file_state(socket.name.as_str()) {
+                    } else if !enabled && handle.get_unit_file_state(get_filename(&socket.name)) {
                         handle.disable_unit_files(socket_path);
                         switch.set_state(false);
                     }
@@ -335,10 +336,10 @@ pub fn launch(config: Config) {
                     let timer = &timers[index as usize];
                     let timer_path = get_filename(&timer.name);
 
-                    if enabled && !handle.get_unit_file_state(timer.name.as_str()) {
+                    if enabled && !handle.get_unit_file_state(get_filename(&timer.name)) {
                         handle.enable_unit_files(timer_path);
                         switch.set_state(true);
-                    } else if !enabled && handle.get_unit_file_state(timer.name.as_str()) {
+                    } else if !enabled && handle.get_unit_file_state(get_filename(&timer.name)) {
                         handle.disable_unit_files(timer_path);
                         switch.set_state(false);
                     }


### PR DESCRIPTION
There's a number of changes here.

- I mostly use `systemctl --user`, so it was inconvenient for me to not have access to user units. This is now supported by the launching with the `--user` flag. All this really required was creating a Session bus rather than a System one.
- I was investigating the reason why the GUI has such a significant latency (it was freezing for 200+ ms whenever I switched between units). I suspected it was due to having to create a dbus connection for each message, and hence rewrote the module to reuse one connection, but the real culprit seemed to have been `get_unit_file_state`, which internally called `list_unit_files` each time, causing latency scaling with the number of unit files in the system. I reimplemented that function via GetUnitFileState, and now there is no perceptible latency.
- General cleanup: fixed all clippy warnings, implemented some TODOS, refactored some functions to reduce code reuse, autoformatted with `cargo fmt`, fixed some warnings Shellcheck gave for the install.sh script, etc.

Bumped the version to 0.5.0 overall, since a feature was added and the internal APIs like `crate::dbus` were notably changed.